### PR TITLE
Adding DeepAI plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "packages/*"
             ],
             "devDependencies": {
+                "@types/deepai": "^1.0.0",
                 "@typescript-eslint/eslint-plugin": "^5.48.1",
                 "@typescript-eslint/parser": "^5.48.1",
                 "eslint": "^8.31.0",
@@ -1809,6 +1810,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@types/deepai": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/deepai/-/deepai-1.0.0.tgz",
+            "integrity": "sha512-VEMnMZc7HivoaOTqJKuIeB8z99JL4obmwKKaNW/HLMp1MvTHxAT5JVl/wToubeyqK74ZMf3D1n9ZSF58ddnMYg==",
+            "dev": true
+        },
         "node_modules/@types/estree": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
@@ -2286,6 +2293,23 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "node_modules/deepai": {
+            "version": "1.0.21",
+            "resolved": "https://registry.npmjs.org/deepai/-/deepai-1.0.21.tgz",
+            "integrity": "sha512-4rB4VlSM5gfkeJOrl4euqrpFF/0eMgCW1TFpqwye9x+f+bXV/pTCcIlXYF9O6cX/WJLx41UvnNVAMadrsjNQZw==",
+            "dependencies": {
+                "axios": "0.25.0",
+                "form-data": "4.0.0"
+            }
+        },
+        "node_modules/deepai/node_modules/axios": {
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+            "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+            "dependencies": {
+                "follow-redirects": "^1.14.7"
+            }
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -3891,10 +3915,12 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "deepai": "^1.0.21",
                 "openai": "^3.1.0"
             },
             "devDependencies": {
                 "@rollup/plugin-typescript": "^10.0.1",
+                "@types/deepai": "^1.0.0",
                 "@types/node": "^18.11.18",
                 "rollup": "^3.9.1",
                 "typescript": "^4.9.4"
@@ -5351,6 +5377,12 @@
             "dev": true,
             "optional": true
         },
+        "@types/deepai": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/deepai/-/deepai-1.0.0.tgz",
+            "integrity": "sha512-VEMnMZc7HivoaOTqJKuIeB8z99JL4obmwKKaNW/HLMp1MvTHxAT5JVl/wToubeyqK74ZMf3D1n9ZSF58ddnMYg==",
+            "dev": true
+        },
         "@types/estree": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
@@ -5680,6 +5712,25 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "deepai": {
+            "version": "1.0.21",
+            "resolved": "https://registry.npmjs.org/deepai/-/deepai-1.0.21.tgz",
+            "integrity": "sha512-4rB4VlSM5gfkeJOrl4euqrpFF/0eMgCW1TFpqwye9x+f+bXV/pTCcIlXYF9O6cX/WJLx41UvnNVAMadrsjNQZw==",
+            "requires": {
+                "axios": "0.25.0",
+                "form-data": "4.0.0"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.25.0",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+                    "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+                    "requires": {
+                        "follow-redirects": "^1.14.7"
+                    }
+                }
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -6109,7 +6160,9 @@
             "version": "file:packages/igel-ai",
             "requires": {
                 "@rollup/plugin-typescript": "^10.0.1",
+                "@types/deepai": "^1.0.0",
                 "@types/node": "^18.11.18",
+                "deepai": "^1.0.21",
                 "openai": "^3.1.0",
                 "rollup": "^3.9.1",
                 "typescript": "^4.9.4"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "format": "prettier --write ."
     },
     "devDependencies": {
+        "@types/deepai": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",
         "eslint": "^8.31.0",

--- a/packages/igel-ai-babylon-ui/src/components/engines/Engines.tsx
+++ b/packages/igel-ai-babylon-ui/src/components/engines/Engines.tsx
@@ -72,6 +72,12 @@ export function Engines() {
                                                     apiKey
                                                 );
                                             break;
+                                        // case SupportedEngines.DEEPAI:
+                                        //     newEngine =
+                                        //         new DeepAIImageGeneratorPlugin(
+                                        //             apiKey
+                                        //         );
+                                            break;
                                         default:
                                             newEngine =
                                                 new OpenAIImageGeneratorPlugin(

--- a/packages/igel-ai/package.json
+++ b/packages/igel-ai/package.json
@@ -13,7 +13,8 @@
     "author": "Raanan Weber",
     "license": "Apache-2.0",
     "dependencies": {
-        "openai": "^3.1.0"
+        "openai": "^3.1.0",
+        "deepai": "^1.0.21"
     },
     "devDependencies": {
         "@rollup/plugin-typescript": "^10.0.1",

--- a/packages/igel-ai/package.json
+++ b/packages/igel-ai/package.json
@@ -13,8 +13,7 @@
     "author": "Raanan Weber",
     "license": "Apache-2.0",
     "dependencies": {
-        "openai": "^3.1.0",
-        "deepai": "^1.0.21"
+        "openai": "^3.1.0"
     },
     "devDependencies": {
         "@rollup/plugin-typescript": "^10.0.1",

--- a/packages/igel-ai/src/core.ts
+++ b/packages/igel-ai/src/core.ts
@@ -1,4 +1,5 @@
 export * from "./imageGenerator";
+export * from "./plugins/DeepAIImageGeneratorPlugin";
 export * from "./plugins/OpenAIImageGeneratorPlugin";
 export * from "./plugins/StableDiffusionImageGeneratorPlugin";
 export * from "./interfaces";

--- a/packages/igel-ai/src/interfaces.ts
+++ b/packages/igel-ai/src/interfaces.ts
@@ -27,6 +27,7 @@ export interface IImageGeneratorPlugin {
 export enum SupportedEngines {
     OPENNI = "OpenNI",
     STABLEDIFFUSION = "StableDiffusion",
+    DEEPAI = "DeepAI",
 }
 
 /**

--- a/packages/igel-ai/src/plugins/DeepAIApiInterfaces.ts
+++ b/packages/igel-ai/src/plugins/DeepAIApiInterfaces.ts
@@ -1,30 +1,16 @@
 export interface IDeepAIImageRequest {
-    prompt: string;
     url: string;
+    prompt: string;
     width?: number;
     height?: number;
-    resultsLength?: number;
-    requestIdentifier?: string;
-    negativePrompt?: string;
-    image?: string;
-    mask?: string;
 }
 
 export interface IDeepAIRequestBody {
-    key: string;
-    prompt: string;
-    negative_prompt: string;
-    init_image: string | null;
-    mask_image: string | null;
-    samples: number;
-    width: number;
-    height: number;
-    prompt_strength: number;
-    num_inference_steps: number;
-    guidance_scale: number;
+    text: string;
+    grid_size: "1" | "2";
+    width: string;
+    height: string;
     seed: string | null;
-    webhook: string | null;
-    track_id: string | null;
 }
 
 export interface IDeepAIResponse {
@@ -32,23 +18,4 @@ export interface IDeepAIResponse {
     generationTime: number;
     id: number;
     output: string[];
-    meta: IDeepAIResponseMetadata;
-}
-
-export interface IDeepAIResponseMetadata {
-    H: number;
-    W: number;
-    enabled_attention_slicing: boolean;
-    file_prefix: string;
-    guidance_scale: number;
-    model: string;
-    n_samples: number;
-    negative_prompt: string;
-    outdir: string;
-    prompt: string;
-    revision: string;
-    safety_checker: string;
-    seed: number;
-    steps: number;
-    vae: string;
 }

--- a/packages/igel-ai/src/plugins/DeepAIApiInterfaces.ts
+++ b/packages/igel-ai/src/plugins/DeepAIApiInterfaces.ts
@@ -1,0 +1,54 @@
+export interface IDeepAIImageRequest {
+    prompt: string;
+    url: string;
+    width?: number;
+    height?: number;
+    resultsLength?: number;
+    requestIdentifier?: string;
+    negativePrompt?: string;
+    image?: string;
+    mask?: string;
+}
+
+export interface IDeepAIRequestBody {
+    key: string;
+    prompt: string;
+    negative_prompt: string;
+    init_image: string | null;
+    mask_image: string | null;
+    samples: number;
+    width: number;
+    height: number;
+    prompt_strength: number;
+    num_inference_steps: number;
+    guidance_scale: number;
+    seed: string | null;
+    webhook: string | null;
+    track_id: string | null;
+}
+
+export interface IDeepAIResponse {
+    status: string;
+    generationTime: number;
+    id: number;
+    output: string[];
+    meta: IDeepAIResponseMetadata;
+}
+
+export interface IDeepAIResponseMetadata {
+    H: number;
+    W: number;
+    enabled_attention_slicing: boolean;
+    file_prefix: string;
+    guidance_scale: number;
+    model: string;
+    n_samples: number;
+    negative_prompt: string;
+    outdir: string;
+    prompt: string;
+    revision: string;
+    safety_checker: string;
+    seed: number;
+    steps: number;
+    vae: string;
+}

--- a/packages/igel-ai/src/plugins/DeepAIImageGeneratorPlugin.ts
+++ b/packages/igel-ai/src/plugins/DeepAIImageGeneratorPlugin.ts
@@ -1,0 +1,197 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import {
+    IImageGeneratorImageToImageOptions,
+    IImageGeneratorInpaintingOptions,
+    IImageGeneratorPlugin,
+    IImageGeneratorResponse,
+    IImageGeneratorTextToImageOptions,
+    IInjectedMethods,
+    SupportedEngines,
+} from "../interfaces";
+import {
+    IStableDiffusionImageRequest,
+    IStableDiffusionRequestBody,
+    IStableDiffusionResponse,
+} from "./StableDiffussionApiInterfaces";
+
+export class DeepAIImageGeneratorPlugin
+    implements IImageGeneratorPlugin
+{
+    public readonly name = SupportedEngines.DEEPAI;
+
+    public constructor(private readonly _apiKey: string) {}
+
+    public injectMethods(_methods: IInjectedMethods): void {
+        // Not used for Stable Diffusion API
+    }
+
+    public async textToImage(
+        prompt: string,
+        options: IImageGeneratorTextToImageOptions
+    ): Promise<IImageGeneratorResponse> {
+        const createImageRequest = this.generateTextToImageRequest(
+            prompt,
+            options
+        );
+
+        // will throw an error if the request is invalid
+        const response = await axios.request<IStableDiffusionResponse>(
+            createImageRequest
+        );
+        return this.responseToReturnFormat(response);
+    }
+
+    public async imageToImage(
+        prompt: string,
+        options: IImageGeneratorImageToImageOptions
+    ): Promise<IImageGeneratorResponse> {
+        if (
+            !options.image ||
+            !DeepAIImageGeneratorPlugin.isString(options.image)
+        ) {
+            throw new Error(
+                "Image URL is required for image to image generation"
+            );
+        }
+
+        const createImageRequest = this.generateImageToImageRequest(
+            prompt,
+            options
+        );
+
+        // will throw an error if the request is invalid
+        const response = await axios.request<IStableDiffusionResponse>(
+            createImageRequest
+        );
+        return this.responseToReturnFormat(response);
+    }
+
+    public async inpainting(
+        prompt: string,
+        options: IImageGeneratorInpaintingOptions
+    ): Promise<IImageGeneratorResponse> {
+        if (
+            !options.mask ||
+            !DeepAIImageGeneratorPlugin.isString(options.mask)
+        ) {
+            throw new Error(
+                "Image URL is required for image to image generation"
+            );
+        }
+
+        const createImageRequest = this.generateInpaintRequest(prompt, options);
+
+        // will throw an error if the request is invalid
+        const response = await axios.request<IStableDiffusionResponse>(
+            createImageRequest
+        );
+        return this.responseToReturnFormat(response);
+    }
+
+    public serialize(): { [key: string]: any } {
+        return {
+            apiKey: this._apiKey,
+        };
+    }
+
+    private generateTextToImageRequest(
+        prompt: string,
+        options: IImageGeneratorTextToImageOptions
+    ): AxiosRequestConfig<IStableDiffusionRequestBody> {
+        return this.generateImageRequest({
+            prompt,
+            url: "https://stablediffusionapi.com/api/v3/text2img",
+            ...options,
+        });
+    }
+
+    private generateImageToImageRequest(
+        prompt: string,
+        options: IImageGeneratorImageToImageOptions
+    ): AxiosRequestConfig<IStableDiffusionRequestBody> {
+        const { image, ...optionsWithoutImage } = options;
+        return this.generateImageRequest({
+            prompt,
+            url: "https://stablediffusionapi.com/api/v3/img2img",
+            image: image as any as string,
+            ...optionsWithoutImage,
+        });
+    }
+
+    private generateInpaintRequest(
+        prompt: string,
+        options: IImageGeneratorInpaintingOptions
+    ): AxiosRequestConfig<IStableDiffusionRequestBody> {
+        const { image: _image, mask, ...optionsWithoutMask } = options;
+        return this.generateImageRequest({
+            prompt,
+            url: "https://stablediffusionapi.com/api/v3/inpaint",
+            mask: mask as unknown as string,
+            ...optionsWithoutMask,
+        });
+    }
+
+    private generateImageRequest(
+        options: IStableDiffusionImageRequest
+    ): AxiosRequestConfig<IStableDiffusionRequestBody> {
+        if (options.width || options.height) {
+            if (
+                options.width &&
+                options.height &&
+                options.width !== options.height
+            ) {
+                console.log(
+                    "Width and height should be equal. Using width value."
+                );
+                options.height = options.width;
+            }
+            if (
+                options.width !== 1024 &&
+                options.width !== 512 &&
+                options.width !== 256
+            ) {
+                console.log(
+                    "Width should be 1024, 512 or 256. Using default value."
+                );
+                options.width = 1024;
+            }
+        }
+
+        return {
+            method: "POST",
+            url: options.url,
+            data: {
+                key: this._apiKey,
+                prompt: options.prompt,
+                negative_prompt: options.negativePrompt ?? "",
+                init_image: (options.image as string) ?? null,
+                mask_image: (options.mask as string) ?? null,
+                samples: options.resultsLength ?? 1,
+                width: options.width ?? 1024,
+                height: options.height ?? 1024,
+                prompt_strength: 1,
+                num_inference_steps: 20,
+                guidance_scale: 7.5,
+                seed: null, // random seed
+                webhook: null,
+                track_id: options.requestIdentifier ?? null,
+            },
+            headers: {
+                "Content-Type": "application/json",
+            },
+        };
+    }
+
+    private responseToReturnFormat(
+        response: AxiosResponse<IStableDiffusionResponse, any>
+    ): IImageGeneratorResponse {
+        return {
+            images: response.data.output,
+            metadata: response.data.meta,
+        };
+    }
+
+    private static isString(obj: unknown): obj is string {
+        return typeof obj === "string";
+    }
+}

--- a/packages/igel-ai/src/plugins/Parser.ts
+++ b/packages/igel-ai/src/plugins/Parser.ts
@@ -13,5 +13,11 @@ export async function Parse(
             return new (
                 await import("./StableDiffusionImageGeneratorPlugin")
             ).StableDiffusionImageGeneratorPlugin(payload.apiKey as string);
+        case SupportedEngines.DEEPAI:
+            return new (
+                await import("./DeepAIImageGeneratorPlugin")
+            ).DeepAIImageGeneratorPlugin(payload.apiKey as string);
+        default:
+            throw new Error("Invalid engine");
     }
 }


### PR DESCRIPTION
Adds the basic infrastructure for a Deep AI plugin.

- DeepAI only seems to support T2I, not I2I or inpainting.
- They don't offer free requests to try, so I couldn't try the code.
- I tried using the npm package for deepai and @types/deepai, but the project was not having it, so I decided to just do a post using axios following their python examples.
- The response type is temporal, I haven't been able to test this, so I have no idea what their response looks like (and their docs don't say).