### PR TITLE
Adding prompt param for img2img

### DIFF
--- a/packages/igel-ai-babylon-ui/src/components/engines/Engines.tsx
+++ b/packages/igel-ai-babylon-ui/src/components/engines/Engines.tsx
@@ -17,6 +17,7 @@ import { Select } from "@fluentui/react-components/unstable";
 import {
     OpenAIImageGeneratorPlugin,
     StableDiffusionImageGeneratorPlugin,
+    DeepAIImageGeneratorPlugin,
     SupportedEngines,
     IImageGeneratorPlugin,
 } from "igel-ai";
@@ -72,11 +73,11 @@ export function Engines() {
                                                     apiKey
                                                 );
                                             break;
-                                        // case SupportedEngines.DEEPAI:
-                                        //     newEngine =
-                                        //         new DeepAIImageGeneratorPlugin(
-                                        //             apiKey
-                                        //         );
+                                        case SupportedEngines.DEEPAI:
+                                             newEngine =
+                                                 new DeepAIImageGeneratorPlugin(
+                                                     apiKey
+                                                 );
                                             break;
                                         default:
                                             newEngine =

--- a/packages/igel-ai-cli/src/cliInterface.ts
+++ b/packages/igel-ai-cli/src/cliInterface.ts
@@ -118,7 +118,7 @@ void yargs(hideBin(process.argv))
         )
         addPlugin(engine, generator, apiKey);
         const prompt = typeof argv.prompt === "string" ? argv.prompt : (argv.prompt as string[]).join(" ");
-        generator.imageToImage(prompt || "", {
+        generator.imageToImage(prompt, {
             image: processImagePath(argv.imagePath as string),
             resultsLength: argv.count as number
         }, engine).then((image) => {

--- a/packages/igel-ai-cli/src/cliInterface.ts
+++ b/packages/igel-ai-cli/src/cliInterface.ts
@@ -1,7 +1,7 @@
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { ImageGenerator, OpenAIImageGeneratorPlugin, StableDiffusionImageGeneratorPlugin, SupportedEngines } from "igel-ai";
+import { ImageGenerator, OpenAIImageGeneratorPlugin, StableDiffusionImageGeneratorPlugin, DeepAIImageGeneratorPlugin, SupportedEngines } from "igel-ai";
 import {
     loadFile,
     saveFile,
@@ -16,8 +16,8 @@ function getEngine(engine: string): SupportedEngines {
     switch (engine.toLowerCase()) {
         case SupportedEngines.STABLEDIFFUSION.toLowerCase():
             return SupportedEngines.STABLEDIFFUSION;
-        // case SupportedEngines.DEEPAI.toLowerCase():
-        //     return SupportedEngines.DEEPAI;
+        case SupportedEngines.DEEPAI.toLowerCase():
+            return SupportedEngines.DEEPAI;
         case SupportedEngines.OPENNI.toLowerCase():
         default:
             return SupportedEngines.OPENNI;
@@ -29,9 +29,9 @@ function addPlugin(engine: SupportedEngines, generator: ImageGenerator, apiKey: 
         case SupportedEngines.STABLEDIFFUSION:
             generator.addPlugin(new StableDiffusionImageGeneratorPlugin(apiKey));
             break;
-        // case SupportedEngines.DEEPAI:
-        //     generator.addPlugin(new DeepAIImageGeneratorPlugin());
-        //     break;
+        case SupportedEngines.DEEPAI:
+            generator.addPlugin(new DeepAIImageGeneratorPlugin(apiKey));
+            break;
         case SupportedEngines.OPENNI:
         default:
             generator.addPlugin(new OpenAIImageGeneratorPlugin(apiKey));
@@ -95,8 +95,13 @@ void yargs(hideBin(process.argv))
                 }
             });
         })
-    .command('image-variation <imagePath>', 'Generate an image variation', (yargs) => {
+    .command('image-variation <prompt> <imagePath>', 'Generate an image variation', (yargs) => {
         return yargs
+            .positional('prompt', {
+                describe: 'The prompt to use',
+                type: 'string',
+                default: 'A 3D scene of a panda on a lion in a forest',
+            })
             .positional('imagePath', {
                 description: 'Local path or URL of the input image',
                 type: 'string',
@@ -112,7 +117,8 @@ void yargs(hideBin(process.argv))
             }
         )
         addPlugin(engine, generator, apiKey);
-        generator.imageToImage(argv.prompt || "", {
+        const prompt = typeof argv.prompt === "string" ? argv.prompt : (argv.prompt as string[]).join(" ");
+        generator.imageToImage(prompt || "", {
             image: processImagePath(argv.imagePath as string),
             resultsLength: argv.count as number
         }, engine).then((image) => {

--- a/packages/igel-ai/src/plugins/DeepAIImageGeneratorPlugin.ts
+++ b/packages/igel-ai/src/plugins/DeepAIImageGeneratorPlugin.ts
@@ -18,7 +18,7 @@ export class DeepAIImageGeneratorPlugin
     public constructor(private readonly _apiKey: string) { }
 
     public injectMethods(_methods: IInjectedMethods): void {
-        // Not used for Stable Diffusion API
+        // Not used for DeepAI API
     }
 
     public async textToImage(

--- a/packages/igel-ai/src/plugins/StableDiffusionImageGeneratorPlugin.ts
+++ b/packages/igel-ai/src/plugins/StableDiffusionImageGeneratorPlugin.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { create } from "domain";
 import {
     IImageGeneratorImageToImageOptions,
     IImageGeneratorInpaintingOptions,
@@ -169,7 +170,7 @@ export class StableDiffusionImageGeneratorPlugin
                 samples: options.resultsLength ?? 1,
                 width: options.width ?? 1024,
                 height: options.height ?? 1024,
-                prompt_strength: 1,
+                strength: 0.7,
                 num_inference_steps: 20,
                 guidance_scale: 7.5,
                 seed: null, // random seed

--- a/packages/igel-ai/src/plugins/StableDiffusionImageGeneratorPlugin.ts
+++ b/packages/igel-ai/src/plugins/StableDiffusionImageGeneratorPlugin.ts
@@ -152,9 +152,9 @@ export class StableDiffusionImageGeneratorPlugin
                 options.width !== 256
             ) {
                 console.log(
-                    "Width should be 1024, 512 or 256. Using default value."
+                    "Width should be 1024, 512 or 256. Using default value (512)."
                 );
-                options.width = 1024;
+                options.width = 512;
             }
         }
 
@@ -168,8 +168,8 @@ export class StableDiffusionImageGeneratorPlugin
                 init_image: (options.image as string) ?? null,
                 mask_image: (options.mask as string) ?? null,
                 samples: options.resultsLength ?? 1,
-                width: options.width ?? 1024,
-                height: options.height ?? 1024,
+                width: options.width ?? 512,
+                height: options.height ?? 512,
                 strength: 0.7,
                 num_inference_steps: 20,
                 guidance_scale: 7.5,

--- a/packages/igel-ai/src/plugins/StableDiffussionApiInterfaces.ts
+++ b/packages/igel-ai/src/plugins/StableDiffussionApiInterfaces.ts
@@ -19,7 +19,7 @@ export interface IStableDiffusionRequestBody {
     samples: number;
     width: number;
     height: number;
-    prompt_strength: number;
+    strength: number;
     num_inference_steps: number;
     guidance_scale: number;
     seed: string | null;


### PR DESCRIPTION
StableDiffusionAPI requires a prompt parameter for img2img generation.

Apart from that:
- Uncommented DeepAI code so it's a possibility to use it (not tested yet as no key).
- Fixed a parameter issue with StableDiffusionAPI (strength instead of prompt_strength).
- Fixed an old comment.